### PR TITLE
Added commands to run image and stop the instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
 		"onCommand:ops.runOpen",
 		"onCommand:ops.build",
 		"onCommand:ops.stop",
-		"onCommand:ops.runWithConfig"
+		"onCommand:ops.runWithConfig",
+		"onCommand:ops.runImage",
+		"onCommand:ops.stopImage"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
@@ -40,6 +42,14 @@
 			{
 				"command": "ops.runWithConfig",
 				"title": "Ops: Run with configuration"
+			},
+			{
+				"command": "ops.runImage",
+				"title": "Ops: Run Image"
+			},
+			{
+				"command": "ops.stopImage",
+				"title": "Ops: Stop Image"
 			}
 		]
 	},

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
 		"onCommand:ops.build",
 		"onCommand:ops.stop",
 		"onCommand:ops.runWithConfig",
-		"onCommand:ops.runImage",
-		"onCommand:ops.stopImage"
+		"onCommand:ops.startInstance",
+		"onCommand:ops.stopInstance"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
@@ -44,12 +44,12 @@
 				"title": "Ops: Run with configuration"
 			},
 			{
-				"command": "ops.runImage",
-				"title": "Ops: Run Image"
+				"command": "ops.startInstance",
+				"title": "Ops: Start Instance"
 			},
 			{
-				"command": "ops.stopImage",
-				"title": "Ops: Stop Image"
+				"command": "ops.stopInstance",
+				"title": "Ops: Stop Instance"
 			}
 		]
 	},

--- a/src/cmd/cmdHandler.ts
+++ b/src/cmd/cmdHandler.ts
@@ -8,8 +8,8 @@ interface Ops {
   run(filePath: string, configPath: string): ChildProcessWithoutNullStreams
   build(filePath: string, configPath: string): ChildProcessWithoutNullStreams
 
-  runImage(name: string): ChildProcessWithoutNullStreams
-  stopImage(name: string): ChildProcessWithoutNullStreams
+  startInstance(name: string): ChildProcessWithoutNullStreams
+  stopInstance(name: string): ChildProcessWithoutNullStreams
   listImages(): string[]
   listInstances(): string[]
 }
@@ -123,7 +123,7 @@ export default class CmdHandler {
     return spawn("kill", ["-9", "" + pid]);
   };
 
-  runImage = async (out: vscode.OutputChannel): Promise<ChildProcessWithoutNullStreams> => {
+  startInstance = async (out: vscode.OutputChannel): Promise<ChildProcessWithoutNullStreams> => {
     let names = this.ops.listImages();
     if (names.length === 0) {
       return Promise.reject("Cannot find created images");
@@ -134,14 +134,14 @@ export default class CmdHandler {
       return Promise.reject("No image selected");
     }
 
-    let proc = this.ops.runImage(name);
+    let proc = this.ops.startInstance(name);
     proc.on("error", function (err) {
       out.appendLine(`Failed to run image '${name}': ${err.message}`);
     });
     return proc;
   };
 
-  stopImage = async (out: vscode.OutputChannel): Promise<ChildProcessWithoutNullStreams> => {
+  stopInstance = async (out: vscode.OutputChannel): Promise<ChildProcessWithoutNullStreams> => {
     let names = this.ops.listInstances();
     if (names.length === 0) {
       return Promise.reject("Cannot find running instances");
@@ -152,7 +152,7 @@ export default class CmdHandler {
       return Promise.reject("No instance selected");
     }
 
-    let proc = this.ops.stopImage(name);
+    let proc = this.ops.stopInstance(name);
     proc.on("error", function (err) {
       out.appendLine(`Failed to stop instance '${name}': ${err.message}`);
     });

--- a/src/cmd/cmdHandler.ts
+++ b/src/cmd/cmdHandler.ts
@@ -7,6 +7,11 @@ import { Nanos } from "./NanosRepo";
 interface Ops {
   run(filePath: string, configPath: string): ChildProcessWithoutNullStreams
   build(filePath: string, configPath: string): ChildProcessWithoutNullStreams
+
+  runImage(name: string): ChildProcessWithoutNullStreams
+  stopImage(name: string): ChildProcessWithoutNullStreams
+  listImages(): string[]
+  listInstances(): string[]
 }
 
 interface NanosRepo {
@@ -116,5 +121,48 @@ export default class CmdHandler {
     await exec(`kill $(ps -o pid= --ppid ${pid})`);
 
     return spawn("kill", ["-9", "" + pid]);
+  };
+
+  runImage = async (out: vscode.OutputChannel): Promise<ChildProcessWithoutNullStreams> => {
+    let names = this.ops.listImages();
+    if (names.length === 0) {
+      return Promise.reject("Cannot find created images");
+    }
+
+    let name = await vscode.window.showQuickPick(names, { placeHolder: 'Select image to run' });
+    if (!name) {
+      return Promise.reject("No image selected");
+    }
+
+    let proc = this.ops.runImage(name);
+    proc.on("error", function (err) {
+      out.appendLine(`Failed to run image '${name}': ${err.message}`);
+    });
+    return proc;
+  };
+
+  stopImage = async (out: vscode.OutputChannel): Promise<ChildProcessWithoutNullStreams> => {
+    let names = this.ops.listInstances();
+    if (names.length === 0) {
+      return Promise.reject("Cannot find running instances");
+    }
+
+    let name = await vscode.window.showQuickPick(names, { placeHolder: 'Select instance to stop' });
+    if (!name) {
+      return Promise.reject("No instance selected");
+    }
+
+    let proc = this.ops.stopImage(name);
+    proc.on("error", function (err) {
+      out.appendLine(`Failed to stop instance '${name}': ${err.message}`);
+    });
+
+    proc.on("close", (code) => {
+      if (code === 0) {
+        out.appendLine(`Instance '${name}' stopped`);
+      }
+    });
+
+    return proc;
   };
 }

--- a/src/cmd/handleCmd.ts
+++ b/src/cmd/handleCmd.ts
@@ -5,12 +5,12 @@ import handleError from './handleError';
 import logStream from './logStream';
 import finishCmd from './finishCmd';
 
-type CommandHandler = () => Promise<ChildProcessWithoutNullStreams>;
+type CommandHandler = (out: vscode.OutputChannel) => Promise<ChildProcessWithoutNullStreams>;
 
 export default function registCmd(cmd: CommandHandler, out: vscode.OutputChannel) {
 	return async () => {
 		try {
-			const stream = await cmd();
+			const stream = await cmd(out);
 			await logStream(stream, out);
 		} catch (e) {
 			handleError(e);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,12 @@ export function activate(context: vscode.ExtensionContext) {
 
 	let stopCmd = vscode.commands.registerCommand('ops.stop', handleCmd(cmdHandler.stop, out));
 	context.subscriptions.push(stopCmd);
+
+	let runImage = vscode.commands.registerCommand("ops.runImage", handleCmd(cmdHandler.runImage, out));
+	context.subscriptions.push(runImage);
+
+	let stopImage = vscode.commands.registerCommand("ops.stopImage", handleCmd(cmdHandler.stopImage, out));
+	context.subscriptions.push(stopImage);
 }
 
 // this method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,11 +31,11 @@ export function activate(context: vscode.ExtensionContext) {
 	let stopCmd = vscode.commands.registerCommand('ops.stop', handleCmd(cmdHandler.stop, out));
 	context.subscriptions.push(stopCmd);
 
-	let runImage = vscode.commands.registerCommand("ops.runImage", handleCmd(cmdHandler.runImage, out));
-	context.subscriptions.push(runImage);
+	let startInstance = vscode.commands.registerCommand("ops.startInstance", handleCmd(cmdHandler.startInstance, out));
+	context.subscriptions.push(startInstance);
 
-	let stopImage = vscode.commands.registerCommand("ops.stopImage", handleCmd(cmdHandler.stopImage, out));
-	context.subscriptions.push(stopImage);
+	let stopInstance = vscode.commands.registerCommand("ops.stopInstance", handleCmd(cmdHandler.stopInstance, out));
+	context.subscriptions.push(stopInstance);
 }
 
 // this method is called when your extension is deactivated

--- a/src/lib/ops.ts
+++ b/src/lib/ops.ts
@@ -1,4 +1,4 @@
-import { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "child_process";
+import { ChildProcessWithoutNullStreams, execSync, SpawnOptionsWithoutStdio } from "child_process";
 
 type Spawn = (command: string, args?: readonly string[] | undefined, options?: SpawnOptionsWithoutStdio | undefined) => ChildProcessWithoutNullStreams;
 
@@ -33,6 +33,51 @@ export default class Ops {
     }
 
     return this._runOps(args);
+  }
+
+  runImage(name: string): ChildProcessWithoutNullStreams {
+    return this._runOps(["--show-errors", "instance", "create", name]);
+  }
+
+  stopImage(name: string): ChildProcessWithoutNullStreams {
+    return this._runOps(["--show-errors", "instance", "delete", name]);
+  }
+
+  listInstances(): string[] {
+    let cmdOut = execSync("ops instance list");
+    return this._extractColumnFromCmdOut(cmdOut.toString(), 2);
+  }
+
+  listImages(): string[] {
+    let cmdOut = execSync("ops image list");
+    return this._extractColumnFromCmdOut(cmdOut.toString(), 1);
+  }
+
+  _extractColumnFromCmdOut(cmdOut: string, colIndex: number): string[] {
+    let rows: string[] = [];
+    let lines = cmdOut.toString().split('\n');
+    if (lines.length === 3) {
+      return rows; // no image listed
+    }
+
+    let columns: string[];
+    let value: string;
+    let line: string;
+    for (let i = 3; i < lines.length; i++) {
+      line = lines[i].trim();
+      if (line.startsWith('+') || line.startsWith('-')) {
+        continue;
+      }
+
+      if (line.length === 0) {
+        continue;
+      }
+
+      columns = lines[i].split('|');
+      value = columns[colIndex].trim();
+      rows.push(value);
+    }
+    return rows;
   }
 
   _runOps(args: string[]): ChildProcessWithoutNullStreams {

--- a/src/lib/ops.ts
+++ b/src/lib/ops.ts
@@ -35,11 +35,11 @@ export default class Ops {
     return this._runOps(args);
   }
 
-  runImage(name: string): ChildProcessWithoutNullStreams {
+  startInstance(name: string): ChildProcessWithoutNullStreams {
     return this._runOps(["--show-errors", "instance", "create", name]);
   }
 
-  stopImage(name: string): ChildProcessWithoutNullStreams {
+  stopInstance(name: string): ChildProcessWithoutNullStreams {
     return this._runOps(["--show-errors", "instance", "delete", name]);
   }
 


### PR DESCRIPTION
My previous branch has conflicts so I create new branch and reapply my changes.

This PR adds command to run existing image and later stop the running instance. Also added `OutputChannel` as command argument to allow writing to editor's output pane.